### PR TITLE
Several related changes

### DIFF
--- a/test/borda_test.erl
+++ b/test/borda_test.erl
@@ -58,9 +58,11 @@ borda_nauru_case() ->
 
 borda_nauru_us2016_case() ->
     Rankings = consensus:borda_rankings(nauru, ballots(us2016)),
-    [ {clinton, 64.0}, {trump, 56.75}, {johnson, GJ}, {stein, 34.25} ] = Rankings,
-    ?assert(GJ > 53.33),
-    ?assert(GJ < 53.34).
+    [ {clinton, 62.0}, {trump, 60.5}, {johnson, GJ}, {stein, JS} ] = Rankings,
+    ?assert(GJ > 52.16),
+    ?assert(GJ < 52.17),
+    ?assert(JS > 33.66),
+    ?assert(JS < 33.67).
 
 %%% PRIVATE FUNCTIONS
 
@@ -79,23 +81,27 @@ ballots() ->
 % These ballots are obviously not real.
 % I wanted to play with one plausible scenario.
 ballots(us2016) ->
-    DemL = ballot:make([clinton, johnson, stein, trump]),
     DemG = ballot:make([clinton, stein, johnson, trump]),
+    DemL = ballot:make([clinton, johnson, stein, trump]),
+    DemR = ballot:make([clinton, trump, johnson, stein]),
+    GOPD = ballot:make([trump, clinton, johnson, stein]),
+    GOPG = ballot:make([trump, stein, johnson, clinton]),
+    GOPL = ballot:make([trump, johnson, clinton, stein]),
     GrnD = ballot:make([stein, clinton, johnson, trump]),
     GrnL = ballot:make([stein, johnson, clinton, trump]),
-    LibG = ballot:make([johnson, stein, clinton, trump]),
     LibD = ballot:make([johnson, clinton, stein, trump]),
+    LibG = ballot:make([johnson, stein, clinton, trump]),
     LibR = ballot:make([johnson, trump, clinton, stein]),
-    GOPL = ballot:make([trump, johnson, clinton, stein]),
-    GOPD = ballot:make([trump, clinton, johnson, stein]),
     lists:flatten([
         lists:duplicate(30, GOPL),
-        lists:duplicate(29, DemL),
-        lists:duplicate(13, DemG),
+        lists:duplicate(25, DemL),
         lists:duplicate(10, GOPD),
+        lists:duplicate(9, DemR),
         lists:duplicate(7, LibR),
+        lists:duplicate(5, DemG),
         lists:duplicate(4, LibD),
-        lists:duplicate(4, LibG),
-        lists:duplicate(2, GrnD),
-        lists:duplicate(1, GrnL)
+        lists:duplicate(3, GrnD),
+        lists:duplicate(3, LibG),
+        lists:duplicate(2, GOPG),
+        lists:duplicate(2, GrnL)
     ]).

--- a/test/borda_test.erl
+++ b/test/borda_test.erl
@@ -94,14 +94,17 @@ ballots(us2016) ->
     LibR = ballot:make([johnson, trump, clinton, stein]),
     lists:flatten([
         lists:duplicate(30, GOPL),
-        lists:duplicate(25, DemL),
         lists:duplicate(10, GOPD),
-        lists:duplicate(9, DemR),
-        lists:duplicate(7, LibR),
-        lists:duplicate(5, DemG),
-        lists:duplicate(4, LibD),
-        lists:duplicate(3, GrnD),
-        lists:duplicate(3, LibG),
         lists:duplicate(2, GOPG),
+
+        lists:duplicate(25, DemL),
+        lists:duplicate(9, DemR),
+        lists:duplicate(5, DemG),
+
+        lists:duplicate(7, LibR),
+        lists:duplicate(4, LibD),
+        lists:duplicate(3, LibG),
+
+        lists:duplicate(3, GrnD),
         lists:duplicate(2, GrnL)
     ]).

--- a/test/borda_test.erl
+++ b/test/borda_test.erl
@@ -14,36 +14,59 @@ borda_test_() ->
             [
                 fun borda_base0_case/0,
                 fun borda_base1_case/0,
-                fun borda_naura_case/0
+                fun borda_dowdell_case/0,
+                fun borda_nauru_case/0,
+                fun borda_nauru_us2016_case/0
             ]
     }.
 
 borda_base0_case() ->
     Rankings = consensus:borda_rankings(base0, ballots()),
     ?assertEqual([
+                  {catherine, 205},
                   {andrew, 153},
                   {brian, 151},
-                  {catherine, 205},
                   {david, 91}
                  ], Rankings).
 
 borda_base1_case() ->
     Rankings = consensus:borda_rankings(base1, ballots()),
     ?assertEqual([
+                  {catherine, 305},
                   {andrew, 253},
                   {brian, 251},
-                  {catherine, 305},
                   {david, 191}
                  ], Rankings).
 
-borda_naura_case() ->
-    Rankings = consensus:borda_rankings(naura, ballots()),
+borda_dowdell_case() ->
+    Rankings = consensus:borda_rankings(dowdell, ballots()),
     ?assertEqual([
                   {andrew, 63.25},
-                  {brian, 49.5},
                   {catherine, 52.5},
+                  {brian, 49.5},
                   {david, 43.08333333333333}
                  ], Rankings).
+
+borda_nauru_case() ->
+    Rankings = consensus:borda_rankings(nauru, ballots()),
+    ?assertEqual([
+                  {andrew, 63.25},
+                  {catherine, 52.5},
+                  {brian, 49.5},
+                  {david, 43.08333333333333}
+                 ], Rankings).
+
+borda_nauru_us2016_case() ->
+    Rankings = consensus:borda_rankings(nauru, ballots(us2016)),
+    [ {clinton, HC}, {trump, DT}, {johnson, GJ}, {stein, JS} ] = Rankings,
+    ?assert(HC > 64.1),
+    ?assert(HC < 64.2),
+    ?assert(DT > 56.24),
+    ?assert(DT < 56.26),
+    ?assert(GJ > 53.33),
+    ?assert(GJ < 53.34),
+    ?assert(JS > 34.58),
+    ?assert(JS < 34.59).
 
 %%% PRIVATE FUNCTIONS
 
@@ -57,4 +80,28 @@ ballots() ->
         lists:duplicate(5, Ballot2),
         lists:duplicate(23, Ballot3),
         lists:duplicate(21, Ballot4)
+    ]).
+
+% These ballots are obviously not real.
+% I wanted to play with one plausible scenario.
+ballots(us2016) ->
+    DemL = ballot:make([clinton, johnson, stein, trump]),
+    DemG = ballot:make([clinton, stein, johnson, trump]),
+    GrnD = ballot:make([stein, clinton, johnson, trump]),
+    GrnL = ballot:make([stein, johnson, clinton, trump]),
+    LibG = ballot:make([johnson, stein, clinton, trump]),
+    LibD = ballot:make([johnson, clinton, stein, trump]),
+    LibR = ballot:make([johnson, trump, clinton, stein]),
+    GOPL = ballot:make([trump, johnson, clinton, stein]),
+    GOPD = ballot:make([trump, clinton, johnson, stein]),
+    lists:flatten([
+        lists:duplicate(30, GOPL),
+        lists:duplicate(29, DemL),
+        lists:duplicate(13, DemG),
+        lists:duplicate(10, GOPD),
+        lists:duplicate(5, LibD),
+        lists:duplicate(5, LibG),
+        lists:duplicate(5, LibR),
+        lists:duplicate(2, GrnD),
+        lists:duplicate(1, GrnL)
     ]).

--- a/test/borda_test.erl
+++ b/test/borda_test.erl
@@ -58,15 +58,9 @@ borda_nauru_case() ->
 
 borda_nauru_us2016_case() ->
     Rankings = consensus:borda_rankings(nauru, ballots(us2016)),
-    [ {clinton, HC}, {trump, DT}, {johnson, GJ}, {stein, JS} ] = Rankings,
-    ?assert(HC > 64.1),
-    ?assert(HC < 64.2),
-    ?assert(DT > 56.24),
-    ?assert(DT < 56.26),
+    [ {clinton, 64.0}, {trump, 56.75}, {johnson, GJ}, {stein, 34.25} ] = Rankings,
     ?assert(GJ > 53.33),
-    ?assert(GJ < 53.34),
-    ?assert(JS > 34.58),
-    ?assert(JS < 34.59).
+    ?assert(GJ < 53.34).
 
 %%% PRIVATE FUNCTIONS
 
@@ -99,9 +93,9 @@ ballots(us2016) ->
         lists:duplicate(29, DemL),
         lists:duplicate(13, DemG),
         lists:duplicate(10, GOPD),
-        lists:duplicate(5, LibD),
-        lists:duplicate(5, LibG),
-        lists:duplicate(5, LibR),
+        lists:duplicate(7, LibR),
+        lists:duplicate(4, LibD),
+        lists:duplicate(4, LibG),
         lists:duplicate(2, GrnD),
         lists:duplicate(1, GrnL)
     ]).


### PR DESCRIPTION
- Ensure Borda rankings are ordered by votes.
- Add `dowdell` alias.
- Add one plausible scenario for Borda in the 2016 US Presidential Election.
- Also fix a typo in `nauru`.